### PR TITLE
feat: elevate leading-blank rules to errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ import config from '@commitlint/config-conventional';
 export default {
   extends: ['@commitlint/config-conventional'],
   rules: {
+    'body-leading-blank': [2, 'always'],
     'footer-leading-blank': [2, 'always'],
     'scope-case': [2, 'always', 'kebab-case'],
     'type-enum': [

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ import config from '@commitlint/config-conventional';
 export default {
   extends: ['@commitlint/config-conventional'],
   rules: {
+    'footer-leading-blank': [2, 'always'],
     'scope-case': [2, 'always', 'kebab-case'],
     'type-enum': [
       2,


### PR DESCRIPTION
## Summary

`@commitlint/config-conventional` sets `body-leading-blank` and
`footer-leading-blank` to **warnings** — they're the only two
Warning-severity rules in the base config, everything else is already
`Error`. That means a body or footer/trailer (e.g. `BREAKING CHANGE:`)
missing its required leading blank line silently passes commitlint
instead of failing it. Found this via a warning slipping through on a
commit in [travi/home-network](https://github.com/travi/home-network).

Two separate commits, since they're independent rule changes:

1. `footer-leading-blank` → `[2, 'always']`
2. `body-leading-blank` → `[2, 'always']`

## Verified (both rules)

- Missing leading blank line → now **fails** (exit 1) with the
  corresponding `*-leading-blank` error.
- Correct leading blank line → still **passes** (exit 0).
- `npm test` (lint:md, lint:sensitive, lint:peer, lint:publish) passes
  clean with both changes.

## Breaking change

Downstream consumers (`travi/commitlint-config-travi` →
`travi/home-network` and others) that were relying on the tolerant
warning for malformed bodies/footers will start failing commitlint
until their commit messages are fixed. Marked as a breaking change
accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)